### PR TITLE
Images from specific views feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/vinspect/Octree"]
 	path = include/vinspect/Octree
-	url = https://github.com/attcs/Octree.git
+	url = https://github.com/LeweC/Octree.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/vinspect/Octree"]
 	path = include/vinspect/Octree
-	url = https://github.com/LeweC/Octree.git
+	url = https://github.com/LeweC/pose_tree.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(vinspect)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 find_package(ament_cmake REQUIRED) 
 find_package(ament_cmake_python REQUIRED)
@@ -10,6 +11,10 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development)
 find_package(PythonLibs 3 REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(TBB REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(rocksdb REQUIRED)
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS src/dense.proto)
 
 list(APPEND CMAKE_MODULE_PATH "/usr/include/tbb/")
 
@@ -26,26 +31,27 @@ endif()
 
 add_compile_options(-Wall -Wextra -Wpedantic)
 include_directories(include)
-
-set(SOURCES src/inspection.cpp src/utils.cpp src/sparse_mesh.cpp)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}) #ToDo probably better to have all .proto file in one folder and inlcude that instead of ${CMAKE_CURRENT_BINARY_DIR}
+set(SOURCES src/inspection.cpp src/utils.cpp src/sparse_mesh.cpp ${PROTO_SRCS} ${PROTO_HDRS})
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
-target_link_libraries(${PROJECT_NAME} TBB::tbb OpenMP::OpenMP_CXX)
+target_link_libraries(${PROJECT_NAME} TBB::tbb OpenMP::OpenMP_CXX rocksdb ${PROTOBUF_LIBRARY})
 
 ament_target_dependencies(${PROJECT_NAME}
   ament_cmake
   Open3D
+  rocksdb
 )
-
 
 pybind11_add_module(vinspect_py src/python_bindings.cpp)
 ament_target_dependencies(vinspect_py PUBLIC
   pybind11
   Python3
   Open3D
+  rocksdb
 )
-target_link_libraries(vinspect_py PUBLIC vinspect)
+target_link_libraries(vinspect_py PUBLIC vinspect rocksdb ${PROTOBUF_LIBRARY})
 set_target_properties(vinspect_py PROPERTIES LINKER_LANGUAGE CXX)
 
 if(BUILD_TESTING)
@@ -81,7 +87,9 @@ ament_export_dependencies(pybind11)
 ament_export_dependencies(Python3)
 ament_export_dependencies(TBB)
 ament_export_dependencies(Open3D)
+ament_export_libraries(rocksdb)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)
-
+ament_export_include_directories(${CMAKE_CURRENT_BINARY_DIR}) #ToDo See line: include_directories(${CMAKE_CURRENT_BINARY_DIR})
+ament_export_include_directories(rocksdb)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,6 @@ ament_export_dependencies(Open3D)
 ament_export_libraries(rocksdb)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)
-ament_export_include_directories(${CMAKE_CURRENT_BINARY_DIR}) #ToDo See line: include_directories(${CMAKE_CURRENT_BINARY_DIR})
+ament_export_include_directories(${CMAKE_CURRENT_BINARY_DIR}) #ToDo See line: 34
 ament_export_include_directories(rocksdb)
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(vinspect)
 
 set(CMAKE_CXX_STANDARD 20)
+set(PYBIND11_FINDPYTHON ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 find_package(ament_cmake REQUIRED) 

--- a/cmake/Findrocksdb.cmake
+++ b/cmake/Findrocksdb.cmake
@@ -1,0 +1,45 @@
+# https://github.com/bro/cmake/blob/master/FindJeMalloc.cmake
+# - Try to find google test headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(Rocksdb)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  ROCKSDB_ROOT_DIR Set this variable to the root installation of
+#                    rocksdb if the module has problems finding
+#                    the proper installation path.
+#
+# Variables defined by this module:
+#
+#  ROCKSDB_FOUND             System has rocksdb libs/headers
+#  ROCKSDB_LIBRARIES         The rocksdb library/libraries
+#  ROCKSDB_INCLUDE_DIR       The location of rocksdb headers
+
+find_path(ROCKSDB_ROOT_DIR
+    NAMES include/rocksdb/db.h
+)
+
+find_library(ROCKSDB_LIBRARIES
+    NAMES rocksdb
+    HINTS ${ROCKSDB_ROOT_DIR}
+)
+
+find_path(ROCKSDB_INCLUDE_DIR
+    NAMES rocksdb/db.h
+    HINTS ${ROCKSDB_ROOT_DIR}/include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(rocksdb DEFAULT_MSG
+    ROCKSDB_LIBRARIES
+    ROCKSDB_INCLUDE_DIR
+)
+
+mark_as_advanced(
+    ROCKSDB_ROOT_DIR
+    ROCKSDB_LIBRARIES
+    ROCKSDB_INCLUDE_DIR
+)

--- a/include/vinspect/inspection.hpp
+++ b/include/vinspect/inspection.hpp
@@ -33,6 +33,16 @@
 #include "vinspect/utils.hpp"
 #include "dense.pb.h"
 
+#include <unsupported/Eigen/EulerAngles>
+/*
+The unsupported implementation for Euler angles is used in this software because the standard 
+implementation uses the ranges [0:pi]x[-pi:pi]x[-pi:pi], but with these ranges ambiguous 
+representations can be achieved. The unsupported implementation overcomes this 
+problem by using the ranges [-pi, pi], [-pi/2, pi/2], [-pi, pi].
+
+https://eigen.tuxfamily.org/dox/unsupported/group__EulerAngles__Module.html
+*/
+
 #define OCTREE_DEPTH 10
 #define MAX_POSES_IN_LEAF 21
 

--- a/include/vinspect/inspection.hpp
+++ b/include/vinspect/inspection.hpp
@@ -22,6 +22,8 @@
 #include <tuple>
 #include <vector>
 
+#include "rocksdb/db.h"
+#include "rocksdb/options.h"
 #include "open3d/Open3D.h"
 #include "open3d/geometry/TriangleMesh.h"
 #include "open3d/io/ModelIO.h"
@@ -29,8 +31,10 @@
 #include "vinspect/Octree/octree.h"
 #include "vinspect/Octree/octree_container.h"
 #include "vinspect/utils.hpp"
+#include "dense.pb.h"
 
 #define OCTREE_DEPTH 10
+#define MAX_POSES_IN_LEAF 21
 
 namespace vinspect
 {
@@ -54,8 +58,10 @@ public:
    * @param dense_sensor_resolution The dense sensor resolution.
    * @param save_path The path where the inspection data should be saved. If
    *None is given, the inspection data will not be saved.
-   * @param inspection_space_min Defines the space in which measurments are recorded
-   * @param inspection_space_max Defines the space in which measurments are recorded
+   * @param inspection_space_3d_min Defines the space in which measurments are recorded
+   * @param inspection_space_3d_max Defines the space in which measurments are recorded
+   * @param inspection_space_6d_min Defines the space in which pose measurments are recorded
+   * @param inspection_space_6d_max Defines the space in which pose measurments are recorded
    * @param sparse_color_min_values Defines the cutoff of the color range
    * @param sparse_color_max_values Defines the cutoff of the color range
    **/
@@ -63,8 +69,10 @@ public:
     std::vector<SensorType> sensor_types, std::vector<std::string> sparse_types,
     std::vector<std::string> sparse_units, std::vector<std::string> joint_names,
     open3d::geometry::TriangleMesh mesh, std::tuple<int, int> dense_sensor_resolution,
-    std::string save_path, std::array<double, 3> inspection_space_min = {-1, -1, -1},
-    std::array<double, 3> inspection_space_max = {1, 1, 1},
+    std::string save_path, std::array<double, 3> inspection_space_3d_min = {-1, -1, -1},
+    std::array<double, 3> inspection_space_3d_max = {1, 1, 1}, std::array<double,
+    6> inspection_space_6d_min = {-1, -1, -1, -1, -1, -1}, std::array<double,
+    6> inspection_space_6d_max = {1, 1, 1, 1, 1, 1},
     std::vector<double> sparse_color_min_values = {},
     std::vector<double> sparse_color_max_values = {});
 
@@ -72,8 +80,10 @@ public:
     std::vector<std::string> sensor_types_names, std::vector<std::string> sparse_types,
     std::vector<std::string> sparse_units, std::vector<std::string> joint_names,
     std::string mesh_file_path, std::tuple<int, int> dense_sensor_resolution, std::string save_path,
-    std::array<double, 3> inspection_space_min = {-1, -1, -1},
-    std::array<double, 3> inspection_space_max = {1, 1, 1},
+    std::array<double, 3> inspection_space_3d_min = {-1, -1, -1},
+    std::array<double, 3> inspection_space_3d_max = {1, 1, 1}, std::array<double,
+    6> inspection_space_6d_min = {-1, -1, -1, -1, -1, -1}, std::array<double,
+    6> inspection_space_6d_max = {1, 1, 1, 1, 1, 1},
     std::vector<double> sparse_color_min_values = {},
     std::vector<double> sparse_color_max_values = {});
   Inspection();
@@ -115,13 +125,43 @@ public:
     const std::string & value_type, const std::vector<uint64_t> & ids) const;
 
   /**
+   * Returns the id of the closest sparse measurment to the given position.
+   * @param pose 6d pose
+   * @return id of the closest sparse measurement
+   */
+  int getClosestDenseMeasurement(const std::array<double, 6> & pose) const;
+
+  /**
+  * Returns the id of the closest sparse measurment to the given position.
+  * @param pose 7d quaternion pose
+  * @return id of the closest sparse measurement
+  */
+  int getClosestDenseMeasurement(const std::array<double, 7> & quat_pose) const;
+
+  inline uint64_t getDenseDataCount() const {return dense_data_count_;}
+
+  /**
    * Returns all dense at the given position.
-   * @param position 3d position
+   * @param position 6d pose
    * @param radius maximum distance to be considered at this position
    * @return numpy array of dense measurements at the given position
    */
-  std::vector<double> getDenseAtPosition(
-    const std::array<double, 3> & position, double radius) const;
+  std::vector<double> getDenseAtPose(
+    const std::array<double, 6> & pose, double radius) const;
+
+  /**
+   * Returns a image retrived from the database based on the given id.
+   * @param id id of the datapoint in the database
+   * @return image as a std::vector<std::vector<uint8_t>>
+   */
+  std::vector<std::vector<std::array<u_int8_t, 3>>> getImageFromId(const int id) const;
+
+  /**
+ * Returns the pose which is retrived from the database based on the given id.
+ * @param id id of the datapoint in the database
+ * @return image as a std::vector<std::vector<uint8_t>>
+ */
+  std::array<double, 6> getDensePoseFromId(const int id) const;
 
   /**
    * Adds a new data point to the inspection
@@ -147,12 +187,21 @@ public:
 
   void finish();
 
+  /**
+   * Extracts the pose from an 4D extrisic matrix
+   * @param extrinsic_matrix extrinsic matrix
+   * @return pose of with orientation as euler angles
+   */
+  std::array<double, 6> transformMatrixToPose(const Eigen::Matrix4d & extrinsic_matrix);
+  std::array<double, 6> quatToEulerPose(const std::array<double, 7> quat_pose) const;
+  std::array<double, 7> eulerToQuatPose(const std::array<double, 6> euler_pose) const;
+
   void integrateImage(
     const open3d::geometry::RGBDImage & image, const int sensor_id,
-    const Eigen::Matrix4d & extrinsic);
+    const Eigen::Matrix4d & extrinsic_optical, const Eigen::Matrix4d & extrinsic_world);
   std::shared_ptr<open3d::geometry::TriangleMesh> extractDenseReconstruction() const;
 
-  inline uint64_t getSparseDataCount() const { return sparse_data_count_; }
+  inline uint64_t getSparseDataCount() const {return sparse_data_count_;}
   inline const std::vector<std::array<double, 3>> & getSparsePosition() const
   {
     return sparse_position_;
@@ -161,13 +210,13 @@ public:
   {
     return sparse_orientation_;
   }
-  inline const bool & getSparseUsage() const { return sparse_usage_; }
-  inline const std::vector<std::vector<double>> & getSparseValue() const { return sparse_value_; }
+  inline const bool & getSparseUsage() const {return sparse_usage_;}
+  inline const std::vector<std::vector<double>> & getSparseValue() const {return sparse_value_;}
   inline const std::vector<Eigen::Vector3d> & getSparseUserColor() const
   {
     return sparse_user_color_;
   }
-  inline const std::vector<double> & getSparseTimestamp() const { return sparse_timestamp_; }
+  inline const std::vector<double> & getSparseTimestamp() const {return sparse_timestamp_;}
   inline const std::vector<double> & getSparseMin() const
   {
     if (!same_min_max_colors_) {
@@ -191,9 +240,9 @@ public:
     intrinsic_recieved_[sensor_id] = true;
   }
 
-  std::vector<std::string> getSparseUnits() { return sparse_units_; }
+  std::vector<std::string> getSparseUnits() {return sparse_units_;}
 
-  uint64_t getIntegratedImagesCount() { return integrated_frames_; }
+  uint64_t getIntegratedImagesCount() {return integrated_frames_;}
 
 private:
   /**
@@ -207,6 +256,16 @@ private:
    * @param filepath path to the file to be saved
    */
   std::string saveStringForSparseEntry(int i) const;
+
+  /**
+   * Serializes a filled protobuf object.
+   * @param i
+   * @param color_img color images to be saved
+   * @param depth_img depth images to be saved
+   */
+  std::string serializedStructForDenseEntry(
+    int i, std::vector<u_int8_t> color_img,
+    std::vector<u_int8_t> depth_img) const;
 
   /**
    * Methods for online saving of data by appending new measurements to the end
@@ -225,18 +284,21 @@ private:
   open3d::geometry::TriangleMesh reference_mesh_;
   std::tuple<int, int> dense_sensor_resolution_;
   std::string save_path_;
-  OrthoTree::OctreePointC sparse_octree_, dense_octree_;
+  OrthoTree::OctreePointC sparse_octree_;
+  OrthoTree::TreePointPoseND<6, double> dense_posetree_;
   std::map<std::string, int> sparse_data_type_to_id_;
   std::vector<double> sparse_timestamp_, dense_timestamp_;
   std::vector<int> sparse_sensor_id_, dense_sensor_id_;
-  std::vector<std::array<double, 3>> sparse_position_, dense_position_;
+  std::vector<std::array<double, 3>> sparse_position_;
+  std::vector<std::array<double, 6>> dense_pose_;
   std::vector<std::array<double, 4>> sparse_orientation_, dense_orientation_;
   std::vector<std::vector<double>> sparse_value_;
   std::vector<Eigen::Vector3d> sparse_user_color_;
-  std::vector<std::vector<double>> dense_image_, dense_depth_image_;
+  std::deque<std::vector<u_int8_t>> dense_image_, dense_depth_image_;
   std::vector<double> robot_timestamp_;
   std::vector<std::vector<double>> robot_states_;
-  OrthoTree::BoundingBox3D inspection_space_;
+  OrthoTree::BoundingBox3D inspection_space_3d_;
+  OrthoTree::BoundingBoxND<6> inspection_space_6d_;
   bool fixed_min_max_values_;
   std::vector<double> sparse_min_values_;
   std::vector<double> sparse_max_values_;
@@ -244,6 +306,12 @@ private:
   std::vector<double> sparse_color_min_values_;
   std::vector<double> sparse_color_max_values_;
   std::thread * saving_thread_;
+  rocksdb::DB * db_;
+  rocksdb::Options db_options_;
+  rocksdb::Status db_status_;
+  std::mutex * mtx_;
+  // Note: mutex needed because the asynchrones append and popback can lead to unpredictable double-free or corrupted size.
+  // As a pointer because default mutex can not be copied with the default copy-constructor we use.
 
   std::shared_ptr<open3d::pipelines::integration::ScalableTSDFVolume> tsdf_volume_;
   std::vector<open3d::camera::PinholeCameraIntrinsic> intrinsic_;

--- a/include/vinspect/inspection.hpp
+++ b/include/vinspect/inspection.hpp
@@ -35,9 +35,9 @@
 
 #include <unsupported/Eigen/EulerAngles>
 /*
-The unsupported implementation for Euler angles is used in this software because the standard 
-implementation uses the ranges [0:pi]x[-pi:pi]x[-pi:pi], but with these ranges ambiguous 
-representations can be achieved. The unsupported implementation overcomes this 
+The unsupported implementation for Euler angles is used in this software because the standard
+implementation uses the ranges [0:pi]x[-pi:pi]x[-pi:pi], but with these ranges ambiguous
+representations can be achieved. The unsupported implementation overcomes this
 problem by using the ranges [-pi, pi], [-pi/2, pi/2], [-pi, pi].
 
 https://eigen.tuxfamily.org/dox/unsupported/group__EulerAngles__Module.html
@@ -142,10 +142,10 @@ public:
   int getClosestDenseMeasurement(const std::array<double, 6> & pose) const;
 
   /**
-  * Returns the id of the closest sparse measurment to the given position.
-  * @param pose 7d quaternion pose
-  * @return id of the closest sparse measurement
-  */
+   * Returns the id of the closest sparse measurment to the given position.
+   * @param pose 7d quaternion pose
+   * @return id of the closest sparse measurement
+   */
   int getClosestDenseMeasurement(const std::array<double, 7> & quat_pose) const;
 
   inline uint64_t getDenseDataCount() const {return dense_data_count_;}
@@ -167,16 +167,23 @@ public:
   std::vector<std::vector<std::array<u_int8_t, 3>>> getImageFromId(const int id) const;
 
   /**
- * Returns the pose which is retrived from the database based on the given id.
- * @param id id of the datapoint in the database
- * @return image as a std::vector<std::vector<uint8_t>>
- */
+   * Returns the pose which is retrived from the database based on the given id.
+   * @param id id of the datapoint in the database
+   * @return image as a std::vector<std::vector<uint8_t>>
+   */
   std::array<double, 6> getDensePoseFromId(const int id) const;
+
+  /**
+   * Returns a percentage of all poses available.
+   * @param percentage percentage poses requested
+   * @return multiple arrays of 6D poses in a vector, as a std::vector<std::array<double, 6>>
+   */
+  std::vector<std::array<double, 6>> getMultiDensePoses(const int percentage) const;
 
   /**
    * Adds a new data point to the inspection
    * @param position 3d position
-   *@param values numpy array of data values
+   * @param values numpy array of data values
    * @param raw_id id of the raw measurements
    * @param insert_in_octree can be set to false if the octree is later recreated to improve performance
    */

--- a/src/dense.proto
+++ b/src/dense.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message Dense{
+    int32 entry_nr = 1;
+    repeated float pose = 2;
+    repeated int32 color_image = 3;
+    repeated int32 depth_image = 4;
+}

--- a/src/inspection.cpp
+++ b/src/inspection.cpp
@@ -128,7 +128,7 @@ Inspection::Inspection(
     // robot_states_ = std::vector<<std::vector<double>>(10000);
   }
 
-  mtx_ = new std::mutex(); //Note: Does this also need to be in the other constructor?
+  mtx_ = new std::mutex();
   finished_ = false;
 }
 

--- a/src/inspection.cpp
+++ b/src/inspection.cpp
@@ -342,15 +342,15 @@ std::array<double, 6> Inspection::transformMatrixToPose(const Eigen::Matrix4d & 
   Eigen::Vector3d translation = extrinsic_matrix.block<3, 1>(0, 3);
 
   Eigen::Matrix3d rotationMatrix = extrinsic_matrix.block<3, 3>(0, 0);
+  Eigen::EulerAnglesXYZd euler_angles(rotationMatrix);
 
-  Eigen::Vector3d euler_angles = rotationMatrix.eulerAngles(0, 1, 2);
   pose[0] = translation[0];
   pose[1] = translation[1];
   pose[2] = translation[2];
 
-  pose[3] = euler_angles[0];
-  pose[4] = euler_angles[1];
-  pose[5] = euler_angles[2];
+  pose[3] = euler_angles.alpha();
+  pose[4] = euler_angles.beta();
+  pose[5] = euler_angles.gamma();
 
   return pose;
 }
@@ -360,15 +360,15 @@ std::array<double, 6> Inspection::quatToEulerPose(const std::array<double, 7> qu
   std::array<double, 6> euler_pose;
 
   Eigen::Quaterniond quat(quat_pose[6], quat_pose[3], quat_pose[4], quat_pose[5]);
-  Eigen::Vector3d euler_angles = quat.toRotationMatrix().eulerAngles(0, 1, 2);
+  Eigen::EulerAnglesXYZd euler_angles(quat.toRotationMatrix());
 
   euler_pose[0] = quat_pose[0];
   euler_pose[1] = quat_pose[1];
   euler_pose[2] = quat_pose[2];
 
-  euler_pose[3] = euler_angles[0];
-  euler_pose[4] = euler_angles[1];
-  euler_pose[5] = euler_angles[2];
+  euler_pose[3] = euler_angles.alpha();
+  euler_pose[4] = euler_angles.beta();
+  euler_pose[5] = euler_angles.gamma();
 
   return euler_pose;
 }

--- a/src/inspection.cpp
+++ b/src/inspection.cpp
@@ -243,6 +243,31 @@ std::array<double, 6> Inspection::getDensePoseFromId(const int id) const
   return pose;
 }
 
+std::vector<std::array<double, 6>> Inspection::getMultiDensePoses(const int percentage) const
+{
+  std::vector<std::array<double, 6>> all_poses;
+  float float_percentage = percentage / 100.0;
+  float x = dense_data_count_ * float_percentage;
+  float entries_to_skip = dense_data_count_ / x;
+  
+  for (size_t i = 0; i < dense_data_count_; i = i + entries_to_skip)
+  {
+    std::string retriveKey = "D_1_" + std::to_string(i);
+    std::string retrivedStringData;
+    std::array<double, 6> pose;
+    db_->Get(rocksdb::ReadOptions(), retriveKey, &retrivedStringData);
+    Dense retrivedEntry;
+    if (retrivedEntry.ParseFromString(retrivedStringData)) {
+      for (size_t j = 0; j < retrivedEntry.pose_size(); j++) {
+        pose[j] = retrivedEntry.pose(j);
+      }
+      all_poses.push_back(pose);
+    }
+  }
+
+  return all_poses;
+}
+
 std::vector<std::vector<std::array<u_int8_t, 3>>> Inspection::getImageFromId(const int id) const
 {
   std::string retriveKey = "D_1_" + std::to_string(id);

--- a/src/python_bindings.cpp
+++ b/src/python_bindings.cpp
@@ -48,13 +48,16 @@ PYBIND11_MODULE(vinspect_py, m)
     py::init<
       std::vector<std::string>, std::vector<std::string>, std::vector<std::string>,
       std::vector<std::string>, std::string, std::tuple<int, int>, std::string,
-      std::array<double, 3>, std::array<double, 3>, std::vector<double>, std::vector<double>>(),
+      std::array<double, 3>, std::array<double, 3>, std::array<double, 6>, std::array<double, 6>,
+      std::vector<double>, std::vector<double>>(),
     py::arg("sensor_types_names"), py::arg("sparse_types") = std::vector<std::string>(),
     py::arg("sparse_units") = std::vector<std::string>(),
     py::arg("joint_names") = std::vector<std::string>(), py::arg("mesh_file_path") = "",
     py::arg("dense_sensor_resolution") = std::tuple<int, int>(), py::arg("save_path") = "",
-    py::arg("inspection_space_min") = std::array<double, 3>(),
-    py::arg("inspection_space_max") = std::array<double, 3>(),
+    py::arg("inspection_space_3d_min") = std::array<double, 3>(),
+    py::arg("inspection_space_3d_max") = std::array<double, 3>(),
+    py::arg("inspection_space_6d_min") = std::array<double, 6>(),
+    py::arg("inspection_space_6d_max") = std::array<double, 6>(),
     py::arg("sparse_min_values") = std::vector<double>(),
     py::arg("sparse_max_values") = std::vector<double>())
   .def("add_sparse_measurement", &Inspection::addSparseMeasurement)


### PR DESCRIPTION
This PR is part of a larger feature for Vinspect across multiple repositories.
Relevant PRs: DLR-MO/vinspect_rviz_plugins#1, DLR-MO/vinspect_ros2#1

These specific changes add the required functionality for the backend/Vinspect part.

- Changed submodule to fork with PoseTrees and added PoseTree for dense functionality
- Added RocksDB as database to store and retrieve dense data
- Added ProtoBuf to serialize dense data for storage in RocksDB
- Added feature to retrieve images from specific views