### PR TITLE
Minor rviz plugin UI changes 

### DIFF
--- a/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
+++ b/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
@@ -44,12 +44,14 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   connect(transparency_slider_, SIGNAL(valueChanged(int)), this, SLOT(onTransparencyChange(int)));
 
   // horizontal divider line
-  QWidget * horizontal_line_widget_1 = new QWidget;
-  horizontal_line_widget_1->setFixedHeight(2);
-  horizontal_line_widget_1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontal_line_widget_1->setStyleSheet(QString("background-color: #c0c0c0;"));
-  sparse_layout->addWidget(horizontal_line_widget_1);
-
+  {
+    auto* horizontal_line_widget = new QWidget;
+    horizontal_line_widget->setFixedHeight(2);
+    horizontal_line_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontal_line_widget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    sparse_layout->addWidget(horizontal_line_widget);
+  }
+  
   // dot size
   sparse_layout->addWidget(new QLabel("Dot radius:"));
   dot_size_input_ = new QLineEdit(QString::fromStdString(std::to_string(start_dot_size)));
@@ -104,11 +106,13 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   sparse_layout->addWidget(new QLabel("Note: Remeshing might take a while"));
 
   // horizontal divider line
-  QWidget * horizontal_line_widget_2 = new QWidget;
-  horizontal_line_widget_2->setFixedHeight(2);
-  horizontal_line_widget_2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontal_line_widget_2->setStyleSheet(QString("background-color: #c0c0c0;"));
-  sparse_layout->addWidget(horizontal_line_widget_2);
+  {
+    auto* horizontal_line_widget = new QWidget;
+    horizontal_line_widget->setFixedHeight(2);
+    horizontal_line_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontal_line_widget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    sparse_layout->addWidget(horizontal_line_widget);
+  }
 
   // horizontal layout for buttons
   QHBoxLayout * hlayout = new QHBoxLayout(this);
@@ -126,63 +130,70 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   connect(clear_sparse_button, &QPushButton::clicked, [this] {clearSparseClick();});
   hlayout->addWidget(clear_sparse_button);
 
+  sparse_layout->addStretch();
+
   // dense settings
-  QGridLayout * dense_layout = new QGridLayout(this);
-  QStringList input_names = {"voxel_length_", "depth_trunc_"};
-  std::reference_wrapper<QLineEdit *> input_objects[] = {
-    voxel_length_, depth_trunc_};
-  int row = 0;
-  int column = 0;
-  for (int i = 0; i < input_names.size(); i++) {
-    input_objects[i].get() = new QLineEdit("");
-    input_objects[i].get()->setPlaceholderText("Set " + input_names[i]);
-    dense_layout->addWidget(input_objects[i], row, column);
-    if (row < 5) {
-      row++;
-    } else {
-      column++;
-      row = 0;
-    }
-  }
-  QPushButton * service_start_button = new QPushButton("Send start request");
+  auto * dense_layout = new QVBoxLayout(this);
+
+  dense_layout->addWidget(new QLabel("Set voxel length:"));
+  voxel_length_ = new QLineEdit(QString::fromStdString(std::to_string(0.02)));
+  voxel_length_->setPlaceholderText("Set voxel length");
+  dense_layout->addWidget(voxel_length_);
+
+  dense_layout->addWidget(new QLabel("Set depth trunc:"));
+  depth_trunc_ = new QLineEdit(QString::fromStdString(std::to_string(0.75)));
+  depth_trunc_->setPlaceholderText("Set depth trunc");
+  dense_layout->addWidget(depth_trunc_);
+
+  auto* h_save_layout = new QHBoxLayout(this);
+  dense_layout->addLayout(h_save_layout);
+
+  auto* service_start_button = new QPushButton("Start");
   connect(service_start_button, &QPushButton::clicked, [this] {requestStartClick();});
-  dense_layout->addWidget(service_start_button, 7, 0, 1, 2);
+  h_save_layout->addWidget(service_start_button);
 
-  QPushButton * default_button = new QPushButton("Set default values");
-  connect(
-    default_button, &QPushButton::clicked, [this, input_objects] {
-      setDefaultClick(input_objects);
-    });
-  dense_layout->addWidget(default_button, 6, 0);
-
-  QPushButton * clear_button = new QPushButton("Clear");
-  connect(
-    clear_button, &QPushButton::clicked, [this, input_objects] {clearClick(input_objects);});
-  dense_layout->addWidget(clear_button, 6, 1);
-
-  QWidget * horizontal_line_widget_3 = new QWidget;
-  horizontal_line_widget_3->setFixedHeight(2);
-  horizontal_line_widget_3->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontal_line_widget_3->setStyleSheet(QString("background-color: #c0c0c0;"));
-  dense_layout->addWidget(horizontal_line_widget_3, 9, 0, 1, 2);
-
-  QPushButton * service_stop_button = new QPushButton("Send stop request");
+  auto* service_stop_button = new QPushButton("Stop");
   connect(service_stop_button, &QPushButton::clicked, [this] {requestStopClick();});
-  dense_layout->addWidget(service_stop_button, 12, 0, 1, 2);
+  h_save_layout->addWidget(service_stop_button);
 
-  QWidget * horizontal_line_widget_4 = new QWidget;
-  horizontal_line_widget_4->setFixedHeight(2);
-  horizontal_line_widget_4->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontal_line_widget_4->setStyleSheet(QString("background-color: #c0c0c0;"));
-  dense_layout->addWidget(horizontal_line_widget_4, 13, 0, 1, 2);
+  {
+    auto* horizontal_line_widget = new QWidget;
+    horizontal_line_widget->setFixedHeight(2);
+    horizontal_line_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontal_line_widget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    dense_layout->addWidget(horizontal_line_widget);
+  }
 
-  QPushButton * dense_req_button = new QPushButton("Get dense data at pose");
+  QPushButton * dense_req_button = new QPushButton("Get dense data near marker");
   connect(dense_req_button, &QPushButton::clicked, [this] {denseReqClick();});
-  dense_layout->addWidget(dense_req_button, 15, 0, 1, 2);
+  dense_layout->addWidget(dense_req_button);
 
-  QPushButton * dense_available_poses_button = new QPushButton("Show available dense poses");
+  {
+    auto* horizontal_line_widget = new QWidget;
+    horizontal_line_widget->setFixedHeight(2);
+    horizontal_line_widget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontal_line_widget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    dense_layout->addWidget(horizontal_line_widget);
+  }
+
+  auto* h_query_percent_slider_layout = new QHBoxLayout(this);
+  dense_layout->addLayout(h_query_percent_slider_layout);
+
+  h_query_percent_slider_layout->addWidget(new QLabel("Fraction:"));
+  multi_pose_percentage = new QSlider(Qt::Horizontal);
+  multi_pose_percentage->setFocusPolicy(Qt::StrongFocus);
+  multi_pose_percentage->setTickPosition(QSlider::TicksBothSides);
+  multi_pose_percentage->setTickInterval(10);
+  multi_pose_percentage->setSingleStep(1);
+  multi_pose_percentage->setTracking(false);
+  multi_pose_percentage->setValue(49);
+  h_query_percent_slider_layout->addWidget(multi_pose_percentage);
+
+  auto* dense_available_poses_button = new QPushButton("Show dense poses");
   connect(dense_available_poses_button, &QPushButton::clicked, [this] {denseAvailablePosesClick();});
-  dense_layout->addWidget(dense_available_poses_button, 16, 0);
+  dense_layout->addWidget(dense_available_poses_button);
+  
+  dense_layout->addStretch();
 
   multi_pose_percentage = new QLineEdit("");
   multi_pose_percentage->setToolTip("Enter an intger from 0 between 100");
@@ -349,21 +360,6 @@ void SettingsPanel::requestStopClick()
   auto future_result = stop_client_->async_send_request(request, response_received_callback);
 }
 
-void SettingsPanel::setDefaultClick(const std::reference_wrapper<QLineEdit *> input_objects[])
-{
-  QStringList default_input = {"0.02", "0.75"};
-  for (int i = 0; i < 2; i++) {
-    input_objects[i].get()->setText(default_input[i]);
-  }
-}
-
-void SettingsPanel::clearClick(const std::reference_wrapper<QLineEdit *> input_objects[])
-{
-  for (int i = 0; i < 2; i++) {
-    input_objects[i].get()->setText("");
-  }
-}
-
 void SettingsPanel::denseReqClick()
 {
   auto message = std_msgs::msg::Empty();
@@ -377,7 +373,7 @@ void SettingsPanel::denseAvailablePosesClick()
   Create new ROS msg with more options like percentage of poses to show, color, heatmap etc. 
   */
   auto message = std_msgs::msg::Int32();
-  int percentage = multi_pose_percentage->text().toInt();
+  int percentage = multi_pose_percentage->value() + 1;
   if (percentage > 0 && percentage <= 100)
   {
     message.data = percentage;

--- a/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
+++ b/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
@@ -195,11 +195,6 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   
   dense_layout->addStretch();
 
-  multi_pose_percentage = new QLineEdit("");
-  multi_pose_percentage->setToolTip("Enter an intger from 0 between 100");
-  multi_pose_percentage->setText("50");
-  dense_layout->addWidget(multi_pose_percentage, 16, 1);
-
   // make tab layout of sparse and dense
   QTabWidget * tab_widget = new QTabWidget(this);
   auto sparse_widget = new QWidget;

--- a/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
+++ b/ros2/vinspect_rviz_plugins/src/settings_panel.cpp
@@ -28,7 +28,8 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   sparse_settings_msg_.clear = false;
 
   // Creates a vertical box layout
-  QVBoxLayout * sparse_layout = new QVBoxLayout(this);
+  auto* sparse_widget = new QWidget;
+  QVBoxLayout * sparse_layout = new QVBoxLayout(sparse_widget);
 
   // Transparency slider
   sparse_layout->addWidget(new QLabel("Transparency:"));
@@ -115,7 +116,7 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   }
 
   // horizontal layout for buttons
-  QHBoxLayout * hlayout = new QHBoxLayout(this);
+  QHBoxLayout * hlayout = new QHBoxLayout();
   sparse_layout->addLayout(hlayout);
 
   QPushButton * pause_button = new QPushButton("Pause");
@@ -133,7 +134,8 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   sparse_layout->addStretch();
 
   // dense settings
-  auto * dense_layout = new QVBoxLayout(this);
+  auto* dense_widget = new QWidget;
+  auto* dense_layout = new QVBoxLayout(dense_widget);
 
   dense_layout->addWidget(new QLabel("Set voxel length:"));
   voxel_length_ = new QLineEdit(QString::fromStdString(std::to_string(0.02)));
@@ -145,7 +147,7 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   depth_trunc_->setPlaceholderText("Set depth trunc");
   dense_layout->addWidget(depth_trunc_);
 
-  auto* h_save_layout = new QHBoxLayout(this);
+  auto* h_save_layout = new QHBoxLayout();
   dense_layout->addLayout(h_save_layout);
 
   auto* service_start_button = new QPushButton("Start");
@@ -176,7 +178,7 @@ SettingsPanel::SettingsPanel(QWidget * parent)
     dense_layout->addWidget(horizontal_line_widget);
   }
 
-  auto* h_query_percent_slider_layout = new QHBoxLayout(this);
+  auto* h_query_percent_slider_layout = new QHBoxLayout();
   dense_layout->addLayout(h_query_percent_slider_layout);
 
   h_query_percent_slider_layout->addWidget(new QLabel("Fraction:"));
@@ -196,9 +198,7 @@ SettingsPanel::SettingsPanel(QWidget * parent)
   dense_layout->addStretch();
 
   // Modality independent UI
-  auto* misc_layout = new QVBoxLayout(this);
-  auto* misc_widget = new QWidget;
-  misc_widget->setLayout(misc_layout);
+  auto* misc_layout = new QVBoxLayout();
 
   auto* export_diconde_req_button = new QPushButton("Export DICONDE");
   connect(export_diconde_req_button, &QPushButton::clicked, [this] {saveDicondeClick();});
@@ -206,16 +206,12 @@ SettingsPanel::SettingsPanel(QWidget * parent)
 
   // make tab layout of sparse and dense
   QTabWidget * tab_widget = new QTabWidget();
-  auto* sparse_widget = new QWidget;
-  auto* dense_widget = new QWidget;
-  sparse_widget->setLayout(sparse_layout);
-  dense_widget->setLayout(dense_layout);
   tab_widget->addTab(sparse_widget, "Sparse Data");
   tab_widget->addTab(dense_widget, "Dense Data");
 
   auto* parent_layout = new QVBoxLayout(this);
   parent_layout->addWidget(tab_widget, 1);  
-  parent_layout->addWidget(misc_widget);
+  parent_layout->addLayout(misc_layout);
 }
 
 void SettingsPanel::save(const rviz_common::Config conf) const {rviz_common::Panel::save(conf);}

--- a/ros2/vinspect_rviz_plugins/src/settings_panel.hpp
+++ b/ros2/vinspect_rviz_plugins/src/settings_panel.hpp
@@ -76,7 +76,7 @@ protected:
 
   QLineEdit * file_path_;
 
-   QLineEdit * multi_pose_percentage;
+  QSlider * multi_pose_percentage;
 
   std::shared_ptr<rclcpp::Node> plugin_node_;
   rclcpp::Publisher<vinspect_msgs::msg::Settings>::SharedPtr settings_publisher_;
@@ -96,8 +96,6 @@ protected Q_SLOTS:
   void pauseClick();
   void resumeClick();
   void clearSparseClick();
-  void setDefaultClick(const std::reference_wrapper<QLineEdit *> input_objects[]);
-  void clearClick(const std::reference_wrapper<QLineEdit *> input_objects[]);
   void requestStartClick();
   void requestStopClick();
   void denseReqClick();

--- a/ros2/vinspect_rviz_plugins/src/status_panel.cpp
+++ b/ros2/vinspect_rviz_plugins/src/status_panel.cpp
@@ -15,13 +15,13 @@ StatusPanel::StatusPanel(QWidget * parent)
 {
   // Creates a vertical box layout
   QVBoxLayout * display_layout = new QVBoxLayout(this);
-  QHBoxLayout * hlayoutlabel = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutlabel = new QHBoxLayout();
   display_layout->addLayout(hlayoutlabel);
   hlayoutlabel->addWidget(new QLabel(""));
   hlayoutlabel->addWidget(new QLabel("Last valid:"));
   hlayoutlabel->addWidget(new QLabel("Last:"));
   // horizontal layout to make number be in same row as label
-  QHBoxLayout * hlayoutx = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutx = new QHBoxLayout();
   display_layout->addLayout(hlayoutx);
   hlayoutx->addWidget(new QLabel("X:"));
   last_position_x_ = new QLabel();
@@ -31,7 +31,7 @@ StatusPanel::StatusPanel(QWidget * parent)
   last_position_in_x_->setText("No data received yet");
   hlayoutx->addWidget(last_position_in_x_);
 
-  QHBoxLayout * hlayouty = new QHBoxLayout(this);
+  QHBoxLayout * hlayouty = new QHBoxLayout();
   display_layout->addLayout(hlayouty);
   hlayouty->addWidget(new QLabel("Y:"));
   last_position_y_ = new QLabel();
@@ -41,7 +41,7 @@ StatusPanel::StatusPanel(QWidget * parent)
   last_position_in_y_->setText("No data received yet");
   hlayouty->addWidget(last_position_in_y_);
 
-  QHBoxLayout * hlayoutz = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutz = new QHBoxLayout();
   display_layout->addLayout(hlayoutz);
   hlayoutz->addWidget(new QLabel("Z:"));
   last_position_z_ = new QLabel();
@@ -51,7 +51,7 @@ StatusPanel::StatusPanel(QWidget * parent)
   last_position_in_z_->setText("No data received yet");
   hlayoutz->addWidget(last_position_in_z_);
 
-  QHBoxLayout * hlayoutv = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutv = new QHBoxLayout();
   display_layout->addLayout(hlayoutv);
   hlayoutv->addWidget(new QLabel("Last value:"));
   last_value_ = new QLabel();
@@ -62,20 +62,22 @@ StatusPanel::StatusPanel(QWidget * parent)
   hlayoutv->addWidget(last_value_in_);
 
   // horizontal divider line
-  QWidget * horizontalLineWidget = new QWidget;
-  horizontalLineWidget->setFixedHeight(2);
-  horizontalLineWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontalLineWidget->setStyleSheet(QString("background-color: #c0c0c0;"));
-  display_layout->addWidget(horizontalLineWidget);
+  {
+    QWidget * horizontalLineWidget = new QWidget;
+    horizontalLineWidget->setFixedHeight(2);
+    horizontalLineWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontalLineWidget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    display_layout->addWidget(horizontalLineWidget);
+  }
 
-  QHBoxLayout * hlayoutn = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutn = new QHBoxLayout();
   display_layout->addLayout(hlayoutn);
   hlayoutn->addWidget(new QLabel("Number of recorded values:"));
   recorded_values_ = new QLabel();
   recorded_values_->setText("0");
   hlayoutn->addWidget(recorded_values_);
 
-  QHBoxLayout * hlayouts = new QHBoxLayout(this);
+  QHBoxLayout * hlayouts = new QHBoxLayout();
   display_layout->addLayout(hlayouts);
   hlayouts->addWidget(new QLabel("Status:"));
   status_text_ = new QLabel();
@@ -83,20 +85,22 @@ StatusPanel::StatusPanel(QWidget * parent)
   hlayouts->addWidget(status_text_);
 
   // horizontal divider line
-  QWidget * horizontalLineWidget2 = new QWidget;
-  horizontalLineWidget2->setFixedHeight(2);
-  horizontalLineWidget2->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-  horizontalLineWidget2->setStyleSheet(QString("background-color: #c0c0c0;"));
-  display_layout->addWidget(horizontalLineWidget2);
+  {
+    QWidget * horizontalLineWidget = new QWidget;
+    horizontalLineWidget->setFixedHeight(2);
+    horizontalLineWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    horizontalLineWidget->setStyleSheet(QString("background-color: #c0c0c0;"));
+    display_layout->addWidget(horizontalLineWidget);
+  }
 
-  QHBoxLayout * hlayoutnd = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutnd = new QHBoxLayout();
   display_layout->addLayout(hlayoutnd);
   hlayoutnd->addWidget(new QLabel("Number of integrated images:"));
   integrated_images_ = new QLabel();
   integrated_images_->setText("0");
   hlayoutnd->addWidget(integrated_images_);
 
-  QHBoxLayout * hlayoutsd = new QHBoxLayout(this);
+  QHBoxLayout * hlayoutsd = new QHBoxLayout();
   display_layout->addLayout(hlayoutsd);
   hlayoutsd->addWidget(new QLabel("Status:"));
   dense_status_text_ = new QLabel();


### PR DESCRIPTION
During #13 I noticed some UI inconsistency, mainly in the dense panel. To reduce the scope of #13 this is now a seperate PR.

Changes:
- No additional button to load/clear default values (same behavior as the sparse panel)
- Use scopes insted of number suffixes
- Use slider for to select the amount of dense poses to display
- Rename a few buttons
- Small layout changes

<img width="200"  alt="Screenshot 2025-12-16 111427" src="https://github.com/user-attachments/assets/a15d8409-401f-42c0-99a1-6711dbe190d7" />