### PR TITLE
Fix linker error.

### DIFF
--- a/ros2/vinspect_rviz_plugins/src/settings_panel.hpp
+++ b/ros2/vinspect_rviz_plugins/src/settings_panel.hpp
@@ -90,7 +90,6 @@ protected:
   vinspect_msgs::msg::Settings sparse_settings_msg_;
 
 protected Q_SLOTS:
-  void onObjectButtonClick(const QString & text);
   void onMeanButtonClick(const QString & text);
   void onColorButtonClick(const QString & text);
   void onDotSizeChange(const std::string & text);


### PR DESCRIPTION
Somehow an unimplemented function ended up in the rviz panel header. This results in a linker error when vinspect is run in an pixi enviroment. Removing the signature from the header fixes the issue.